### PR TITLE
created favourite locations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'devise_invitable', '~> 2.0', '>= 2.0.1'
 
 gem 'devise-jwt', '~> 0.5.9'
 gem 'geocoder', '~> 1.3', '>= 1.3.7'
+gem 'google_distance_matrix'
 gem 'google_places_autocomplete'
 gem 'haml-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,12 @@ GEM
     geocoder (1.6.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    google_business_api_url_signer (0.1.3)
+      activesupport (>= 3.2.0)
+    google_distance_matrix (0.6.4)
+      activemodel (>= 3.2.13, < 6.2)
+      activesupport (>= 3.2.13, < 6.2)
+      google_business_api_url_signer (~> 0.1.3)
     google_places_autocomplete (0.0.6)
       hashie
       httparty (~> 0.14, >= 0.14.0)
@@ -391,6 +397,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   geocoder (~> 1.3, >= 1.3.7)
+  google_distance_matrix
   google_places_autocomplete
   haml-rails
   jbuilder (~> 2.7)

--- a/app/controllers/favourite_locations_controller.rb
+++ b/app/controllers/favourite_locations_controller.rb
@@ -40,7 +40,7 @@ class FavouriteLocationsController < ApplicationController
   private
 
   def location_params
-    params.require(:favourite_location).permit(:name, :address)
+    params.require(:favourite_location).permit(:name, :address, :description)
   end
 
   def favourite_location

--- a/app/controllers/favourite_locations_controller.rb
+++ b/app/controllers/favourite_locations_controller.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class FavouriteLocationsController < ApplicationController
+  # GET /api/favourite_locations/
+  def index
+    render_response(
+      current_user.favourite_locations.map do |favourite_location|
+        favourite_location.present.favourite_locations_page_context
+      end
+    )
+  end
+
+  # GET /api/favourite_locations/:id
+  def show
+    render_response(favourite_location.present.favourite_locations_page_context)
+  end
+
+  # POST /api/favourite_locations/
+  def create
+    FavouriteLocations::CreateService.perform(location_params.merge(current_user: current_user))
+
+    render_success_response({ message: 'Successfully added to Favorites' }, :created)
+  end
+
+  # PUT /api/favourite_locations/:id
+  def update
+    FavouriteLocations::UpdateService.perform(location_params.merge(favourite_location: favourite_location,
+                                                                    current_user: current_user))
+
+    render_success_response({ message: 'Successfully updated' }, :ok)
+  end
+
+  # DELETE /api/favourite_locations/:id
+  def destroy
+    FavouriteLocations::DestroyService.perform(favourite_location: favourite_location, current_user: current_user)
+
+    render_success_response({ message: 'Successfully deleted from Favorites' }, :no_content)
+  end
+
+  private
+
+  def location_params
+    params.require(:favourite_location).permit(:name, :address)
+  end
+
+  def favourite_location
+    FavouriteLocation.find(params[:id])
+  end
+end

--- a/app/controllers/users/distance_matrix_controller.rb
+++ b/app/controllers/users/distance_matrix_controller.rb
@@ -16,4 +16,3 @@ module Users
     end
   end
 end
-

--- a/app/controllers/users/distance_matrix_controller.rb
+++ b/app/controllers/users/distance_matrix_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Users
+  class DistanceMatrixController < ApplicationController
+    # POST /api/users/distance_time/calculate
+    def calculate
+      result = Users::DistanceMatrixService.perform(points_params)
+
+      render_success_response(data: result)
+    end
+
+    private
+
+    def points_params
+      params.require(:distance).permit(:origin, :destination)
+    end
+  end
+end
+

--- a/app/models/favourite_location.rb
+++ b/app/models/favourite_location.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Favourite Locations for User
+class FavouriteLocation < ApplicationRecord
+  belongs_to :user
+
+  validates :name, :address, presence: true, uniqueness: {
+    scope: :user_id,
+    message: 'is already in your Favourite Locations'
+  }
+
+  private
+
+  def presenter_class
+    FavouriteLocationPresenter
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,8 @@ class User < ApplicationRecord
            class_name: 'FamilyConnection',
            foreign_key: :receiver_user_id
 
+  has_many :favourite_locations
+
   accepts_nested_attributes_for :family
   has_one_attached :avatar
   validates :email, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }, if: :email_present?

--- a/app/presenters/favourite_location_presenter.rb
+++ b/app/presenters/favourite_location_presenter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class FavouriteLocationPresenter < ApplicationPresenter
-  MODEL_ATTRIBUTES = %i[id user_id name address created_at updated_at].freeze
+  MODEL_ATTRIBUTES = %i[id user_id name address description created_at updated_at].freeze
 
   delegate(*MODEL_ATTRIBUTES, to: :record)
 

--- a/app/presenters/favourite_location_presenter.rb
+++ b/app/presenters/favourite_location_presenter.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class FavouriteLocationPresenter < ApplicationPresenter
+  MODEL_ATTRIBUTES = %i[id user_id name address created_at updated_at].freeze
+
+  delegate(*MODEL_ATTRIBUTES, to: :record)
+
+  def favourite_locations_page_context
+    properties
+  end
+
+  private
+
+  def properties
+    record.attributes.symbolize_keys.slice(*MODEL_ATTRIBUTES)
+  end
+end
+

--- a/app/presenters/favourite_location_presenter.rb
+++ b/app/presenters/favourite_location_presenter.rb
@@ -15,4 +15,3 @@ class FavouriteLocationPresenter < ApplicationPresenter
     record.attributes.symbolize_keys.slice(*MODEL_ATTRIBUTES)
   end
 end
-

--- a/app/services/favourite_locations/application_service.rb
+++ b/app/services/favourite_locations/application_service.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# ApplicationService with current_user method
+module FavouriteLocations
+  class ApplicationService < ApplicationService
+    private
+
+    def current_user
+      params[:current_user].presence
+    end
+
+    def favourite_location
+      params[:favourite_location].presence
+    end
+
+    def location_attributes
+      params.slice(:name, :address).presence
+    end
+  end
+end

--- a/app/services/favourite_locations/create_service.rb
+++ b/app/services/favourite_locations/create_service.rb
@@ -9,6 +9,8 @@ module FavouriteLocations
     # - address [String] the address we add
 
     def call
+      raise ArgumentError, 'Current user is missing' unless current_user
+
       current_user.favourite_locations.create!(location_attributes)
     end
   end

--- a/app/services/favourite_locations/create_service.rb
+++ b/app/services/favourite_locations/create_service.rb
@@ -7,6 +7,7 @@ module FavouriteLocations
     # - current_user: [User] current_user
     # - name [String] the name we add
     # - address [String] the address we add
+    # - description [Text] the description we add
 
     def call
       raise ArgumentError, 'Current user is missing' unless current_user

--- a/app/services/favourite_locations/create_service.rb
+++ b/app/services/favourite_locations/create_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FavouriteLocations
+  # Service for adding favourite address to the user
+  class CreateService < ApplicationService
+    # @attr_reader params [Hash]
+    # - current_user: [User] current_user
+    # - name [String] the name we add
+    # - address [String] the address we add
+
+    def call
+      current_user.favourite_locations.create!(location_attributes)
+    end
+  end
+end

--- a/app/services/favourite_locations/destroy_service.rb
+++ b/app/services/favourite_locations/destroy_service.rb
@@ -8,8 +8,8 @@ module FavouriteLocations
     # - current_user: [User] current_user
 
     def call
-      raise ArgumentError, "Favourite Location not found" unless favourite_location
-      raise ArgumentError, "You are not allowed to destroy this data" unless
+      raise ArgumentError, 'Favourite Location not found' unless favourite_location
+      raise ArgumentError, 'You are not allowed to destroy this data' unless
         current_user.favourite_locations.include?(favourite_location)
 
       favourite_location.destroy

--- a/app/services/favourite_locations/destroy_service.rb
+++ b/app/services/favourite_locations/destroy_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module FavouriteLocations
+  # Service for user creation
+  class DestroyService < ApplicationService
+    # @attr_reader params [Hash]
+    # - favourite_location [FavouriteLocation]
+    # - current_user: [User] current_user
+
+    def call
+      raise ArgumentError, "Favourite Location not found" unless favourite_location
+      raise ArgumentError, "You are not allowed to destroy this data" unless
+        current_user.favourite_locations.include?(favourite_location)
+
+      favourite_location.destroy
+    end
+  end
+end

--- a/app/services/favourite_locations/update_service.rb
+++ b/app/services/favourite_locations/update_service.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module FavouriteLocations
+  # Service for user updating
+  class UpdateService < ApplicationService
+    # @attr_reader params [Hash]
+    # - favourite_location [FavouriteLocation]
+    # - current_user: [User] current_user
+    # - name [String] the name we add
+    # - address [String] the address we add
+
+    def call
+      raise ArgumentError, "Favourite Location not found" unless favourite_location
+      raise ArgumentError, "You are not allowed to update this data" unless current_user.favourite_locations.include?(favourite_location)
+
+      favourite_location.update!(location_attributes)
+    end
+  end
+end

--- a/app/services/favourite_locations/update_service.rb
+++ b/app/services/favourite_locations/update_service.rb
@@ -4,7 +4,7 @@ module FavouriteLocations
   # Service for user updating
   class UpdateService < ApplicationService
     # @attr_reader params [Hash]
-    # - favourite_location: [FavouriteLocation] 
+    # - favourite_location: [FavouriteLocation]
     # - current_user: [User] current_user
     # - name [String] the name we add
     # - address [String] the address we add

--- a/app/services/favourite_locations/update_service.rb
+++ b/app/services/favourite_locations/update_service.rb
@@ -4,14 +4,15 @@ module FavouriteLocations
   # Service for user updating
   class UpdateService < ApplicationService
     # @attr_reader params [Hash]
-    # - favourite_location [FavouriteLocation]
+    # - favourite_location: [FavouriteLocation] 
     # - current_user: [User] current_user
     # - name [String] the name we add
     # - address [String] the address we add
 
     def call
-      raise ArgumentError, "Favourite Location not found" unless favourite_location
-      raise ArgumentError, "You are not allowed to update this data" unless current_user.favourite_locations.include?(favourite_location)
+      raise ArgumentError, 'Favourite Location not found' unless favourite_location
+      raise ArgumentError, 'You are not allowed to update this data' unless
+        current_user.favourite_locations.include?(favourite_location)
 
       favourite_location.update!(location_attributes)
     end

--- a/app/services/favourite_locations/update_service.rb
+++ b/app/services/favourite_locations/update_service.rb
@@ -8,6 +8,7 @@ module FavouriteLocations
     # - current_user: [User] current_user
     # - name [String] the name we add
     # - address [String] the address we add
+    # - description [Text] the description we add
 
     def call
       raise ArgumentError, 'Favourite Location not found' unless favourite_location

--- a/app/services/payments/customers/create_service.rb
+++ b/app/services/payments/customers/create_service.rb
@@ -19,9 +19,7 @@ module Payments
       def find_or_create_customer
         if user.stripe_customer_id
           stripe_customer = Stripe::Customer.retrieve({ id: user.stripe_customer_id })
-          if stripe_customer
-            stripe_customer = Stripe::Customer.update(stripe_customer.id, { source: stripe_token })
-          end
+          stripe_customer = Stripe::Customer.update(stripe_customer.id, { source: stripe_token }) if stripe_customer
         else
           stripe_customer = Stripe::Customer.create({
                                                       email: user.email,

--- a/app/services/users/distance_matrix_service.rb
+++ b/app/services/users/distance_matrix_service.rb
@@ -4,8 +4,8 @@ module Users
   # Service for autocomplete addresses using Google Place Autocomplete
   class DistanceMatrixService < ApplicationService
     def call
-      raise ArgumentError, "Origin must be provided" unless params[:origin]
-      raise ArgumentError, "Destination must be provided" unless params[:destination]
+      raise ArgumentError, 'Origin must be provided' unless params[:origin]
+      raise ArgumentError, 'Destination must be provided' unless params[:destination]
 
       prepare_matrix
       prepare_response
@@ -15,15 +15,20 @@ module Users
 
     def prepare_response
       response = distance_matrix_client.data.first.first
-      if response.status == 'ok'
+      case response[:status]
+      when 'ok'
         {
-          distance_text: response.distance_text,
-          distance_in_meters: response.distance_in_meters,
-          duration_text: response.duration_text,
-          duration_in_seconds: response.duration_in_seconds
+          distance_text: response[:distance_text],
+          distance_in_meters: response[:distance_in_meters],
+          duration_text: response[:duration_text],
+          duration_in_seconds: response[:duration_in_seconds]
         }
-      else
-        { error: 'Check the data' }
+      when 'not_found'
+        raise ArgumentError, 'Origin or Destination not found'
+      when 'zero_results'
+        raise ArgumentError, 'No route could be found between Origin or Destination'
+      when 'max_route_length_exceeded'
+        raise ArgumentError, 'Requested route is too long and cannot be processed'
       end
     end
 

--- a/app/services/users/distance_matrix_service.rb
+++ b/app/services/users/distance_matrix_service.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Users
+  # Service for autocomplete addresses using Google Place Autocomplete
+  class DistanceMatrixService < ApplicationService
+    def call
+      raise ArgumentError, "Origin must be provided" unless params[:origin]
+      raise ArgumentError, "Destination must be provided" unless params[:destination]
+
+      prepare_matrix
+      prepare_response
+    end
+
+    private
+
+    def prepare_response
+      response = distance_matrix_client.data.first.first
+      if response.status == 'ok'
+        {
+          distance_text: response.distance_text,
+          distance_in_meters: response.distance_in_meters,
+          duration_text: response.duration_text,
+          duration_in_seconds: response.duration_in_seconds
+        }
+      else
+        { error: 'Check the data' }
+      end
+    end
+
+    def prepare_matrix
+      distance_matrix_client.origins << origin
+      distance_matrix_client.destinations << destination
+    end
+
+    def origin
+      GoogleDistanceMatrix::Place.new(address: params[:origin])
+    end
+
+    def destination
+      GoogleDistanceMatrix::Place.new(address: params[:destination])
+    end
+
+    def distance_matrix_client
+      @_distance_matrix_client ||= GoogleDistanceMatrix::Matrix.new
+    end
+  end
+end

--- a/config/initializers/google_distance_matrix.rb
+++ b/config/initializers/google_distance_matrix.rb
@@ -1,0 +1,5 @@
+GoogleDistanceMatrix.configure_defaults do |config|
+  config.mode = 'driving'
+  config.avoid = 'tolls'
+  config.google_api_key = ENV['GOOGLE_PLACES_API_KEY']
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
 
     post 'payments/create_customer', to: 'payments#create_customer', as: :create_customer
     post 'payments/create_charge', to: 'payments#create_charge', as: :create_charge
+    resources :favourite_locations
   end
 
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       delete 'users/logout', to: 'users/sessions#destroy'
 
       post 'users/address_autocomplete/complete', to: 'users/address_autocomplete#complete', as: :address_autocomplete_complete
+      post 'users/distance_time/calculate', to: 'users/distance_matrix#calculate', as: :distance_matrix_calculate
     end
 
     get 'brands', to: 'vehicles#brands'

--- a/db/migrate/20210913082106_create_favourite_locations.rb
+++ b/db/migrate/20210913082106_create_favourite_locations.rb
@@ -4,6 +4,7 @@ class CreateFavouriteLocations < ActiveRecord::Migration[6.0]
       t.references :user, null: false, foreign_key: true
       t.string :name
       t.string :address
+      t.text :description
 
       t.timestamps
     end

--- a/db/migrate/20210913082106_create_favourite_locations.rb
+++ b/db/migrate/20210913082106_create_favourite_locations.rb
@@ -1,0 +1,11 @@
+class CreateFavouriteLocations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :favourite_locations do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :name
+      t.string :address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2021_09_13_082106) do
     t.bigint "user_id", null: false
     t.string "name"
     t.string "address"
+    t.text "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_favourite_locations_on_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_17_125825) do
+ActiveRecord::Schema.define(version: 2021_09_13_082106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -71,6 +71,15 @@ ActiveRecord::Schema.define(version: 2021_06_17_125825) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["receiver_user_id"], name: "index_family_connections_on_receiver_user_id"
     t.index ["requestor_user_id"], name: "index_family_connections_on_requestor_user_id"
+  end
+
+  create_table "favourite_locations", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "name"
+    t.string "address"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_favourite_locations_on_user_id"
   end
 
   create_table "friends", force: :cascade do |t|
@@ -216,5 +225,6 @@ ActiveRecord::Schema.define(version: 2021_06_17_125825) do
   add_foreign_key "devices", "users"
   add_foreign_key "family_connections", "users", column: "receiver_user_id"
   add_foreign_key "family_connections", "users", column: "requestor_user_id"
+  add_foreign_key "favourite_locations", "users"
   add_foreign_key "users", "families"
 end

--- a/spec/controllers/favourite_locations_controller_spec.rb
+++ b/spec/controllers/favourite_locations_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe FavouriteLocationsController, type: :controller do
+
+end

--- a/spec/controllers/favourite_locations_controller_spec.rb
+++ b/spec/controllers/favourite_locations_controller_spec.rb
@@ -1,30 +1,52 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe FavouriteLocationsController, type: :controller do
   describe 'routing' do
-    it { expect(get: '/api/favourite_locations')
-           .to route_to(controller: 'favourite_locations', action: 'index', format: :json) }
-    it { expect(get: '/api/favourite_locations/1')
-           .to route_to(controller: 'favourite_locations', action: 'show', format: :json, id: '1') }
-    it { expect(post: '/api/favourite_locations')
-           .to route_to(controller: 'favourite_locations', action: 'create', format: :json) }
-    it { expect(put: '/api/favourite_locations/1')
-           .to route_to(controller: 'favourite_locations', action: 'update', format: :json, id: '1') }
-    it { expect(delete: '/api/favourite_locations/1')
-           .to route_to(controller: 'favourite_locations', action: 'destroy', format: :json, id: '1') }
+    it do
+      expect(get: '/api/favourite_locations').to route_to(controller: 'favourite_locations',
+                                                          action: 'index',
+                                                          format: :json)
+    end
+    it do
+      expect(get: '/api/favourite_locations/1').to route_to(controller: 'favourite_locations',
+                                                            action: 'show',
+                                                            format: :json,
+                                                            id: '1')
+    end
+    it do
+      expect(post: '/api/favourite_locations').to route_to(controller: 'favourite_locations',
+                                                           action: 'create',
+                                                           format: :json)
+    end
+    it do
+      expect(put: '/api/favourite_locations/1').to route_to(controller: 'favourite_locations',
+                                                            action: 'update',
+                                                            format: :json,
+                                                            id: '1')
+    end
+    it do
+      expect(delete: '/api/favourite_locations/1').to route_to(controller: 'favourite_locations',
+                                                               action: 'destroy',
+                                                               format: :json,
+                                                               id: '1')
+    end
   end
 
   let!(:favourite_location) { create(:favourite_location, user: current_user) }
   let(:current_user) { create(:user) }
   let(:headers) { Devise::JWT::TestHelpers.auth_headers({}, current_user) }
 
-  before { request.headers.merge! headers }
+  before { request.headers.merge!(headers) }
 
   describe 'GET#index' do
     let(:send_request) { get :index, format: :json }
-    let(:expected_response) { current_user.favourite_locations.map do |favourite_location|
-      favourite_location.present.favourite_locations_page_context
-    end.to_json }
+    let(:expected_response) do
+      current_user.favourite_locations.map do |favourite_location|
+        favourite_location.present.favourite_locations_page_context
+      end.to_json
+    end
 
     context 'with token provided' do
       before { send_request }
@@ -66,7 +88,8 @@ RSpec.describe FavouriteLocationsController, type: :controller do
 
   describe 'POST#create' do
     let(:send_request) { post :create, params: { favourite_location: favourite_location.attributes }, format: :json }
-    let(:expected_response) { { success: true, message: 'Successfully added to Favorites'}.to_json }
+    let(:expected_response) { { success: true, message: 'Successfully added to Favorites' } .to_json }
+
     before do
       allow(FavouriteLocations::CreateService).to receive(:perform).and_return(:favourite_location)
       send_request
@@ -80,10 +103,10 @@ RSpec.describe FavouriteLocationsController, type: :controller do
   end
 
   describe 'PUT#update' do
-    let(:send_request) { put :update,
-                             params: { id: favourite_location.id, favourite_location: favourite_location.attributes },
-                             as: :json }
-    let(:expected_response) { { success: true, message: 'Successfully updated'}.to_json }
+    let(:send_request) do
+      put :update, params: { id: favourite_location.id, favourite_location: favourite_location.attributes }, as: :json
+    end
+    let(:expected_response) { { success: true, message: 'Successfully updated' } .to_json }
 
     before do
       allow(FavouriteLocations::UpdateService).to receive(:perform).and_return(:favourite_location)
@@ -98,10 +121,8 @@ RSpec.describe FavouriteLocationsController, type: :controller do
   end
 
   describe 'DELETE#destroy' do
-    let(:send_request) { delete :destroy,
-                             params: { id: favourite_location.id },
-                                format: :json }
-    let(:expected_response) { { success: true, message: 'Successfully deleted from Favorites'}.to_json }
+    let(:send_request) { delete :destroy, params: { id: favourite_location.id }, format: :json }
+    let(:expected_response) { { success: true, message: 'Successfully deleted from Favorites' } .to_json }
 
     before do
       allow(FavouriteLocations::DestroyService).to receive(:perform)

--- a/spec/controllers/favourite_locations_controller_spec.rb
+++ b/spec/controllers/favourite_locations_controller_spec.rb
@@ -1,5 +1,116 @@
 require 'rails_helper'
 
 RSpec.describe FavouriteLocationsController, type: :controller do
+  describe 'routing' do
+    it { expect(get: '/api/favourite_locations')
+           .to route_to(controller: 'favourite_locations', action: 'index', format: :json) }
+    it { expect(get: '/api/favourite_locations/1')
+           .to route_to(controller: 'favourite_locations', action: 'show', format: :json, id: '1') }
+    it { expect(post: '/api/favourite_locations')
+           .to route_to(controller: 'favourite_locations', action: 'create', format: :json) }
+    it { expect(put: '/api/favourite_locations/1')
+           .to route_to(controller: 'favourite_locations', action: 'update', format: :json, id: '1') }
+    it { expect(delete: '/api/favourite_locations/1')
+           .to route_to(controller: 'favourite_locations', action: 'destroy', format: :json, id: '1') }
+  end
 
+  let!(:favourite_location) { create(:favourite_location, user: current_user) }
+  let(:current_user) { create(:user) }
+  let(:headers) { Devise::JWT::TestHelpers.auth_headers({}, current_user) }
+
+  before { request.headers.merge! headers }
+
+  describe 'GET#index' do
+    let(:send_request) { get :index, format: :json }
+    let(:expected_response) { current_user.favourite_locations.map do |favourite_location|
+      favourite_location.present.favourite_locations_page_context
+    end.to_json }
+
+    context 'with token provided' do
+      before { send_request }
+
+      it { expect(response.content_type).to include('application/json') }
+      it { expect(response).to have_http_status(:success) }
+      it 'render JSON with list of favourite places' do
+        expect(response.body).to eq(expected_response)
+      end
+    end
+
+    context 'with missing token' do
+      let(:headers) { {} }
+
+      include_examples 'with missing token'
+    end
+  end
+
+  describe 'GET#show' do
+    let(:send_request) { get :show, params: { id: favourite_location.id }, format: :json }
+    let(:expected_response) { favourite_location.present.favourite_locations_page_context.to_json }
+
+    context 'with token provided' do
+      before { send_request }
+
+      it { expect(response.content_type).to include('application/json') }
+      it { expect(response).to have_http_status(:success) }
+      it 'return JSON with favourite place' do
+        expect(response.body).to eq(expected_response)
+      end
+    end
+
+    context 'with missing token' do
+      let(:headers) { {} }
+
+      include_examples 'with missing token'
+    end
+  end
+
+  describe 'POST#create' do
+    let(:send_request) { post :create, params: { favourite_location: favourite_location.attributes }, format: :json }
+    let(:expected_response) { { success: true, message: 'Successfully added to Favorites'}.to_json }
+    before do
+      allow(FavouriteLocations::CreateService).to receive(:perform).and_return(:favourite_location)
+      send_request
+    end
+
+    it { expect(response.content_type).to include('application/json') }
+    it { expect(response).to have_http_status(:created) }
+    it 'return JSON with favourite place' do
+      expect(response.body).to eq(expected_response)
+    end
+  end
+
+  describe 'PUT#update' do
+    let(:send_request) { put :update,
+                             params: { id: favourite_location.id, favourite_location: favourite_location.attributes },
+                             as: :json }
+    let(:expected_response) { { success: true, message: 'Successfully updated'}.to_json }
+
+    before do
+      allow(FavouriteLocations::UpdateService).to receive(:perform).and_return(:favourite_location)
+      send_request
+    end
+
+    it { expect(response.content_type).to include('application/json') }
+    it { expect(response).to have_http_status(:ok) }
+    it 'return JSON with favourite place' do
+      expect(response.body).to eq(expected_response)
+    end
+  end
+
+  describe 'DELETE#destroy' do
+    let(:send_request) { delete :destroy,
+                             params: { id: favourite_location.id },
+                                format: :json }
+    let(:expected_response) { { success: true, message: 'Successfully deleted from Favorites'}.to_json }
+
+    before do
+      allow(FavouriteLocations::DestroyService).to receive(:perform)
+      send_request
+    end
+
+    it { expect(response).to have_http_status(:no_content) }
+    it 'return JSON with favourite place' do
+      expect(response.body).to eq(expected_response)
+    end
+  end
 end

--- a/spec/controllers/users/distance_matrix_controller_spec.rb
+++ b/spec/controllers/users/distance_matrix_controller_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::DistanceMatrixController, type: :controller do
+  describe 'routes' do
+    it { is_expected.to route(:post, '/api/users/distance_time/calculate').to(action: :calculate, format: :json) }
+  end
+
+  let(:headers) { Devise::JWT::TestHelpers.auth_headers({}, current_user) }
+  let(:current_user) { create(:user) }
+
+  before { request.headers.merge!(headers) }
+
+  describe 'POST#calculate' do
+    let(:send_request) do
+      post :calculate,
+           params: { distance: { origin: 'Inverdoorn Nature Reserve, Breede River DC, Южная Африка',
+                                 destination: 'проспект Соборный, 169, Запорожье, Запорожская область, Украина' } },
+           format: :json
+    end
+    let(:distances) do
+      {
+        "distance_text": '16,020 km',
+        "distance_in_meters": 16_020_180,
+        "duration_text": '8 days 15 hours',
+        "duration_in_seconds": 745_007
+      }
+    end
+    let(:expected_response) { { success: true, data: distances } }
+
+    before do
+      allow(Users::DistanceMatrixService).to receive(:perform).and_return(distances)
+      send_request
+    end
+
+    it { expect(response.content_type).to include('application/json') }
+    it { expect(response).to have_http_status(:success) }
+    it 'render JSON with list of favourite places' do
+      expect(response.body).to eq(expected_response.to_json)
+    end
+  end
+end

--- a/spec/factories/favourite_location.rb
+++ b/spec/factories/favourite_location.rb
@@ -7,4 +7,3 @@ FactoryBot.define do
     address { Faker::Address.full_address }
   end
 end
-

--- a/spec/factories/favourite_location.rb
+++ b/spec/factories/favourite_location.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     user
     name { Faker::Address.community }
     address { Faker::Address.full_address }
+    description { Faker::Lorem.sentence }
   end
 end

--- a/spec/factories/favourite_location.rb
+++ b/spec/factories/favourite_location.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :favourite_location do
+    user
+    name { Faker::Address.community }
+    address { Faker::Address.full_address }
+  end
+end
+

--- a/spec/models/favourite_location_spec.rb
+++ b/spec/models/favourite_location_spec.rb
@@ -9,16 +9,17 @@ RSpec.describe FavouriteLocation, type: :model do
     end
   end
 
-  describe 'assotiation' do
+  describe 'association' do
     it { is_expected.to belong_to(:user) }
   end
 
   describe 'validation' do
     subject { build(:favourite_location) }
-    it { should validate_uniqueness_of(:name).scoped_to(:user_id)
-                                             .with_message('is already in your Favourite Locations') }
-    it { should validate_uniqueness_of(:address).scoped_to(:user_id)
-                                                .with_message('is already in your Favourite Locations') }
+    it do
+      should validate_uniqueness_of(:name).scoped_to(:user_id).with_message('is already in your Favourite Locations')
+    end
+    it do
+      should validate_uniqueness_of(:address).scoped_to(:user_id).with_message('is already in your Favourite Locations')
+    end
   end
 end
-

--- a/spec/models/favourite_location_spec.rb
+++ b/spec/models/favourite_location_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe FavouriteLocation, type: :model do
   describe 'columns' do
-    %i[id user_id name address created_at updated_at].each do |field|
+    %i[id user_id name address description created_at updated_at].each do |field|
       it { is_expected.to have_db_column(field) }
     end
   end

--- a/spec/models/favourite_location_spec.rb
+++ b/spec/models/favourite_location_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe FavouriteLocation, type: :model do
   describe 'assotiation' do
     it { is_expected.to belong_to(:user) }
   end
+
+  describe 'validation' do
+    subject { build(:favourite_location) }
+    it { should validate_uniqueness_of(:name).scoped_to(:user_id)
+                                             .with_message('is already in your Favourite Locations') }
+    it { should validate_uniqueness_of(:address).scoped_to(:user_id)
+                                                .with_message('is already in your Favourite Locations') }
+  end
 end
 

--- a/spec/models/favourite_location_spec.rb
+++ b/spec/models/favourite_location_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FavouriteLocation, type: :model do
+  describe 'columns' do
+    %i[id user_id name address created_at updated_at].each do |field|
+      it { is_expected.to have_db_column(field) }
+    end
+  end
+
+  describe 'assotiation' do
+    it { is_expected.to belong_to(:user) }
+  end
+end
+

--- a/spec/presenters/favourite_location_presenter_spec.rb
+++ b/spec/presenters/favourite_location_presenter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FavouriteLocationPresenter do
+  let(:location) { create(:favourite_location) }
+
+  describe 'constants' do
+    describe 'MODEL_ATTRIBUTES' do
+      let(:attributes_list) { %i[id user_id name address description created_at updated_at] }
+      subject { described_class::MODEL_ATTRIBUTES }
+
+      it { is_expected.to eq attributes_list }
+    end
+  end
+
+  describe '#page_content' do
+    let(:expected_presenter) { location.attributes.symbolize_keys }
+    subject { described_class.new(location).favourite_locations_page_context }
+
+    it { is_expected.to be_instance_of Hash }
+    it { is_expected.to eq expected_presenter }
+  end
+
+  describe 'delegates' do
+    subject { described_class.new(location) }
+
+    described_class::MODEL_ATTRIBUTES.each do |method|
+      it { is_expected.to delegate_method(method).to :record }
+    end
+  end
+end

--- a/spec/services/favourite_locations/create_service_spec.rb
+++ b/spec/services/favourite_locations/create_service_spec.rb
@@ -23,8 +23,7 @@ RSpec.describe FavouriteLocations::CreateService do
     context 'with invalid params' do
       let(:params) { favourite_locations_attributes }
 
-      it { expect{ subject }.to raise_error ArgumentError, 'Current user is missing' }
+      it { expect { subject }.to raise_error ArgumentError, 'Current user is missing' }
     end
   end
 end
-

--- a/spec/services/favourite_locations/create_service_spec.rb
+++ b/spec/services/favourite_locations/create_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FavouriteLocations::CreateService do
+  describe '#call' do
+    let(:current_user) { create(:user) }
+    let(:favourite_locations_attributes) { attributes_for(:favourite_location) }
+    let(:params) { favourite_locations_attributes.merge(current_user: current_user) }
+
+    subject { described_class.perform(params) }
+
+    context 'with valid params' do
+      it { expect(subject.class).to eq(FavouriteLocation) }
+      it { expect { subject }.to change(FavouriteLocation, :count).by(1) }
+      it { expect { subject }.to_not raise_error }
+      it 'Favourite Location created after perform, belongs to current user' do
+        subject
+        expect(subject.user).to eq(current_user)
+      end
+    end
+
+    context 'with invalid params' do
+      let(:params) { favourite_locations_attributes }
+
+      it { expect{ subject }.to raise_error ArgumentError, 'Current user is missing' }
+    end
+  end
+end
+

--- a/spec/services/favourite_locations/destroy_service_spec.rb
+++ b/spec/services/favourite_locations/destroy_service_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FavouriteLocations::DestroyService do
+  describe '#call' do
+    let(:current_user) { create(:user) }
+    let!(:favourite_location) { create(:favourite_location, user: current_user) }
+    let(:params) { { favourite_location: favourite_location, current_user: current_user } }
+
+    subject { described_class.perform(params) }
+
+    context 'with valid params' do
+      it { expect { subject }.to change(FavouriteLocation, :count).by(-1) }
+      it { expect { subject }.to_not raise_error }
+    end
+
+    context 'without favourite_location' do
+      let(:params) { { favourite_location: nil, current_user: current_user } }
+
+      it { expect{ subject }.to raise_error ArgumentError, 'Favourite Location not found' }
+    end
+
+    context 'if favourite_location doesnt belong to user' do
+      let(:params) { { favourite_location: 777, current_user: current_user } }
+
+      it { expect{ subject }.to raise_error ArgumentError, 'You are not allowed to destroy this data' }
+    end
+  end
+end

--- a/spec/services/favourite_locations/destroy_service_spec.rb
+++ b/spec/services/favourite_locations/destroy_service_spec.rb
@@ -18,13 +18,13 @@ RSpec.describe FavouriteLocations::DestroyService do
     context 'without favourite_location' do
       let(:params) { { favourite_location: nil, current_user: current_user } }
 
-      it { expect{ subject }.to raise_error ArgumentError, 'Favourite Location not found' }
+      it { expect { subject }.to raise_error ArgumentError, 'Favourite Location not found' }
     end
 
     context 'if favourite_location doesnt belong to user' do
       let(:params) { { favourite_location: 777, current_user: current_user } }
 
-      it { expect{ subject }.to raise_error ArgumentError, 'You are not allowed to destroy this data' }
+      it { expect { subject }.to raise_error ArgumentError, 'You are not allowed to destroy this data' }
     end
   end
 end

--- a/spec/services/favourite_locations/update_service_spec.rb
+++ b/spec/services/favourite_locations/update_service_spec.rb
@@ -7,8 +7,10 @@ RSpec.describe FavouriteLocations::UpdateService do
     let(:current_user) { create(:user) }
     let!(:favourite_location) { create(:favourite_location, user: current_user) }
     let(:new_favourite_locations_attributes) { attributes_for(:favourite_location) }
-    let(:params) { new_favourite_locations_attributes.merge(favourite_location: favourite_location,
-                                                            current_user: current_user) }
+    let(:params) do
+      new_favourite_locations_attributes.merge(favourite_location: favourite_location,
+                                               current_user: current_user)
+    end
 
     subject { described_class.perform(params) }
 
@@ -16,26 +18,28 @@ RSpec.describe FavouriteLocations::UpdateService do
       it { expect { subject }.to_not change(FavouriteLocation, :count) }
       it { expect { subject }.to_not raise_error }
 
-      it { expect { subject }.to change(favourite_location, :name)
-                                   .from(favourite_location.name)
-                                   .to(new_favourite_locations_attributes[:name]) }
-      it { expect { subject }.to change(favourite_location, :address)
-                                   .from(favourite_location.address)
-                                   .to(new_favourite_locations_attributes[:address]) }
+      it do
+        expect { subject }.to change(favourite_location, :name)
+          .from(favourite_location.name)
+          .to(new_favourite_locations_attributes[:name])
+      end
+      it do
+        expect { subject }.to change(favourite_location, :address)
+          .from(favourite_location.address)
+          .to(new_favourite_locations_attributes[:address])
+      end
     end
 
     context 'without favourite_location' do
-      let(:params) { new_favourite_locations_attributes.merge(favourite_location: nil,
-                                                              current_user: current_user) }
+      let(:params) { new_favourite_locations_attributes.merge(favourite_location: nil, current_user: current_user) }
 
-      it { expect{ subject }.to raise_error ArgumentError, 'Favourite Location not found' }
+      it { expect { subject }.to raise_error ArgumentError, 'Favourite Location not found' }
     end
 
     context 'if favourite_location doesnt belong to user' do
-      let(:params) { new_favourite_locations_attributes.merge(favourite_location: 777,
-                                                              current_user: current_user) }
+      let(:params) { new_favourite_locations_attributes.merge(favourite_location: 777, current_user: current_user) }
 
-      it { expect{ subject }.to raise_error ArgumentError, 'You are not allowed to update this data' }
+      it { expect { subject }.to raise_error ArgumentError, 'You are not allowed to update this data' }
     end
   end
 end

--- a/spec/services/favourite_locations/update_service_spec.rb
+++ b/spec/services/favourite_locations/update_service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FavouriteLocations::UpdateService do
+  describe '#call' do
+    let(:current_user) { create(:user) }
+    let!(:favourite_location) { create(:favourite_location, user: current_user) }
+    let(:new_favourite_locations_attributes) { attributes_for(:favourite_location) }
+    let(:params) { new_favourite_locations_attributes.merge(favourite_location: favourite_location,
+                                                            current_user: current_user) }
+
+    subject { described_class.perform(params) }
+
+    context 'with valid params' do
+      it { expect { subject }.to_not change(FavouriteLocation, :count) }
+      it { expect { subject }.to_not raise_error }
+
+      it { expect { subject }.to change(favourite_location, :name)
+                                   .from(favourite_location.name)
+                                   .to(new_favourite_locations_attributes[:name]) }
+      it { expect { subject }.to change(favourite_location, :address)
+                                   .from(favourite_location.address)
+                                   .to(new_favourite_locations_attributes[:address]) }
+    end
+
+    context 'without favourite_location' do
+      let(:params) { new_favourite_locations_attributes.merge(favourite_location: nil,
+                                                              current_user: current_user) }
+
+      it { expect{ subject }.to raise_error ArgumentError, 'Favourite Location not found' }
+    end
+
+    context 'if favourite_location doesnt belong to user' do
+      let(:params) { new_favourite_locations_attributes.merge(favourite_location: 777,
+                                                              current_user: current_user) }
+
+      it { expect{ subject }.to raise_error ArgumentError, 'You are not allowed to update this data' }
+    end
+  end
+end

--- a/spec/services/users/distance_matrix_service_spec.rb
+++ b/spec/services/users/distance_matrix_service_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Users::DistanceMatrixService do
+  let(:expected_response) do
+    {
+      distance_text: '6.0 km',
+      distance_in_meters: 5973,
+      duration_text: '10 min',
+      duration_in_seconds: 587
+    }
+  end
+  let(:distance_matrix_client) do
+    double(:distance_matrix_client,
+           origins: [],
+           destinations: [],
+           data:
+             [
+               [
+                 status: 'ok',
+                 distance_text: '6.0 km',
+                 distance_in_meters: 5973,
+                 duration_text: '10 min',
+                 duration_in_seconds: 587
+               ]
+             ])
+  end
+
+  before do
+    allow(GoogleDistanceMatrix::Matrix).to receive(:new).and_return(distance_matrix_client)
+  end
+
+  describe '#call' do
+    subject do
+      described_class.perform({ origin: 'Inverdoorn Nature Reserve, Breede River DC, Южная Африка',
+                                destination: 'проспект Соборный, 6, Запорожье, Запорожская обл, Украина' })
+    end
+
+    context "when status = 'ok'" do
+      it { expect(subject).to eq(expected_response) }
+    end
+
+    context "when status = 'not_found'" do
+      let(:distance_matrix_client) do
+        double(:distance_matrix_client,
+               origins: [],
+               destinations: [],
+               data: [[status: 'not_found']])
+      end
+    end
+
+    context "when status = 'zero_results'" do
+      let(:distance_matrix_client) do
+        double(:distance_matrix_client,
+               origins: [],
+               destinations: [],
+               data: [[status: 'zero_results']])
+      end
+
+      it { expect { subject }.to raise_error(ArgumentError, 'No route could be found between Origin or Destination') }
+    end
+
+    context "when status = 'max_route_length_exceeded'" do
+      let(:distance_matrix_client) do
+        double(:distance_matrix_client,
+               origins: [],
+               destinations: [],
+               data: [[status: 'max_route_length_exceeded']])
+      end
+
+      it { expect { subject }.to raise_error(ArgumentError, 'Requested route is too long and cannot be processed') }
+    end
+
+    context 'without destination' do
+      subject { described_class.perform({ origin: 'Inverdoorn Nature Reserve, Breede River DC, Южная Африка' }) }
+
+      it { expect { subject }.to raise_error(ArgumentError, 'Destination must be provided') }
+    end
+
+    context 'without origin' do
+      subject { described_class.perform({ destination: 'проспект Соборный, 6, Запорожье, Запорожская обл, Украина' }) }
+
+      it { expect { subject }.to raise_error(ArgumentError, 'Origin must be provided') }
+    end
+  end
+end


### PR DESCRIPTION
Workflow:
Start Address and End Address
    ◦ Are looked up from Google Autocomplete Address Lookup
    ◦ Can be saved as Favorites following the Favorite screens Mockup
    ◦ Once Start Address and End Address is populated:
        ▪ calculate the distance and approximate route time and display it on the screen. 
        ▪ Update the map screen to display start and end destinations and connected lines as a suggested route.

**Favourite Locations**
Created model FavouriteLocations with fields: name, address, description. The model has validations, and relation.
Added routes.
Created controller favourite_locations_controller with CRUD operations and white-list params.
Created presenter FavouriteLocationPresenter.
Created services for CRUD operations.
Covered with RSpec.

**Calculate distance**
Added gem 'google_distance_matrix'.
Added routes.
Created service, that calculates distance between start and spot locations.
Covered with RSpec.

_Update the map screen to display start and end destinations and connected lines as a suggested route._ - in my opinion this implements on the frontend.